### PR TITLE
Add a year to LICENSE to match ISC format

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The ISC License
 
-Copyright (c) npm, Inc.
+Copyright 2021 (c) npm, Inc.
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above


### PR DESCRIPTION
The ISC license should include a year in the Copyright as per https://opensource.org/licenses/ISC
