### PR TITLE
fix: bin entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "GitHub Inc.",
   "main": "lib/index.js",
   "bin": {
-    "installed-package-contents": "index.js"
+    "installed-package-contents": "lib/index.js"
   },
   "license": "ISC",
   "scripts": {


### PR DESCRIPTION
Fixes the install issue by correcting the bin path to `lib/index.js`.

As described by @curtisman:

> Looks like [this PR](https://github.com/npm/installed-package-contents/pull/12) moved `index.js` to `lib/index.js`. But `package.json`'s `bin` entry [here](https://github.com/npm/installed-package-contents/blob/main/package.json?rgh-link-date=2022-10-19T01%3A54%3A00Z#L8) still point it at the root.

https://github.com/npm/installed-package-contents/issues/24#issuecomment-1283274279

## References

Fixes #24