### PR TITLE
fix: add shell line so bin works

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,5 @@
+#! /usr/bin/env node
+
 // to GET CONTENTS for folder at PATH (which may be a PACKAGE):
 // - if PACKAGE, read path/package.json
 //   - if bins in ../node_modules/.bin, add those to result


### PR DESCRIPTION
Allow package to execute under bash/nvm

<!-- What / Why -->
Without the crunch bang command, the command line under bash does not know to use node
<!-- Describe the request in detail. What it does and why it's being changed. -->
Adds the crunch bang so that installed-package-contents can execute at the CLI under bash. Otherwise, it generates an error on line 1 since bash does not recognize / comments. This fix allows bash to correctly supply the interpreter for the file and it works like charm.

## References
No references - guess no one tried this under nvm and bash like I did. WIth the correction, I can execute the program directly.
