### PR TITLE
fix!: align to npm 11 node engine range

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@npmcli/eslint-config": "^5.0.0",
-    "@npmcli/template-oss": "4.27.1",
+    "@npmcli/template-oss": "4.24.3",
     "tap": "^16.3.0"
   },
   "dependencies": {
@@ -36,11 +36,11 @@
     "lib/"
   ],
   "engines": {
-    "node": "^18.17.0 || >=20.5.0"
+    "node": "^20.17.0 || >=22.9.0"
   },
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
-    "version": "4.27.1",
+    "version": "4.24.3",
     "publish": true
   },
   "tap": {


### PR DESCRIPTION
This PR updates the Node.js engine requirement to align with npm 11.

## Changes
- Updated `engines.node` in package.json to `^20.17.0 || >=22.9.0`

## Breaking Change
This is a breaking change as it drops support for Node.js versions outside the specified range.

**New requirement:** Node.js `^20.17.0 || >=22.9.0`